### PR TITLE
Update Traefik to v35.0.0 and fix health check

### DIFF
--- a/clusters/infra/traefik/traefik-crds.yaml
+++ b/clusters/infra/traefik/traefik-crds.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: traefik-crds
@@ -7,16 +7,16 @@ spec:
   interval: 30m
   url: https://github.com/traefik/traefik-helm-chart.git
   ref:
-    tag: v32.1.1  # Use the version that matches your Traefik version
+    tag: v35.0.0  # Use the version that matches your Traefik version
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: traefik-crds
   namespace: flux-system
 spec:
   interval: 15m
-  prune: false
+  prune: true
   sourceRef:
     kind: GitRepository
     name: traefik-crds
@@ -24,4 +24,4 @@ spec:
   healthChecks:
     - apiVersion: apiextensions.k8s.io/v1
       kind: CustomResourceDefinition
-      name: ingressroutes.traefik.containo.us
+      name: ingressroutes.traefik.io

--- a/clusters/infra/traefik/traefik-helm-release.yaml
+++ b/clusters/infra/traefik/traefik-helm-release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: traefik
-      version: '32.1.1'
+      version: '35.0.0'
       sourceRef:
         kind: HelmRepository
         name: traefik


### PR DESCRIPTION
The Traefik version is updated to v35.0.0 to leverage new features, bug fixes, and performance improvements. This ensures the ingress controller benefits from the latest advancements. A health check problem was also addressed as part of this update.

The following changes were made:

- Updated Traefik CRDs GitRepository to source the latest Traefik Helm chart version (v35.0.0).
- Enabled pruning in the Kustomization to remove obsolete resources.
- Updated the API version for Kustomization to v1.
- Upgraded the Traefik Helm chart version from 32.1.1 to 35.0.0 in the infrastructure cluster.